### PR TITLE
Implement DIY coverage tooling

### DIFF
--- a/src/main/java/org/mockito/Coverage.java
+++ b/src/main/java/org/mockito/Coverage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class Coverage {
+    /**
+     * Store the branches reached for each specific function (identified by name, or other consistent method)
+     */
+    private static final HashMap<String, HashSet<Integer>> branchesReached = new HashMap<>();
+    private static final HashMap<String, Integer> branchesTotal = new HashMap<>();
+    public Coverage() {}
+
+    /**
+     * Set the total amount of branches for a given function identifier.
+     * @param function The function identifier.
+     * @param totalBranches The total amount of branches for that function.
+     */
+    public static void setTotalBranches(String function, int totalBranches) {
+        branchesTotal.put(function, totalBranches);
+    }
+
+    /**
+     * Marks the branch as having been reached at some point.
+     * @param function The function in which the branch was reached.
+     * @param branchID The unique identifier for the branch that was reached.
+     */
+    public static void reached(String function, int branchID) {
+        if (!branchesReached.containsKey(function)) branchesReached.put(function, new HashSet<>());
+        branchesReached.get(function).add(branchID);
+        writeCoverage(function);
+    }
+
+    /**
+     * Prints the branch coverage for a specific function. Undefined behaviour if totalBranches
+     * is not positive.
+     * @param function The name of the function which was previously used when denoting the branches as having been reached.
+     */
+    public static void printCoverage(String function) {
+        System.out.println(getPrintCoverage(function));
+    }
+
+    /**
+     * Write the current branch coverage to disk.
+     * @param function The function identifier.
+     */
+    public static void writeCoverage(String function) {
+        File f = new File("./build/coverage/" + function + ".txt");
+        f.getParentFile().mkdirs();
+        try {
+            FileWriter fw = new FileWriter(f);
+            BufferedWriter bw = new BufferedWriter(fw);
+            bw.write(getPrintCoverage(function));
+            bw.close();
+            fw.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static int getTotalBranches(String function) {
+        int totalBranches = 1;
+        if (branchesTotal.get(function) != null) totalBranches = branchesTotal.get(function);
+        if (totalBranches == 0) totalBranches = 1;
+        return totalBranches;
+    }
+
+    private static String getPrintCoverage(String function) {
+        String str = "============================\n";
+        int totalBranches = getTotalBranches(function);
+        int branches = branchesReached.get(function) != null ? branchesReached.get(function).size() : 0;
+        str += String.format("Coverage for %s: %.1f%%\n", function, ((double) branches * 100) / totalBranches);
+        str += "Taken branchIDs:";
+        for (Integer branch : branchesReached.get(function)) {
+            str += " " + branch;
+        }
+        str += "\n============================\n";
+        return str;
+    }
+}

--- a/src/main/java/org/mockito/Coverage.java
+++ b/src/main/java/org/mockito/Coverage.java
@@ -36,29 +36,20 @@ public class Coverage {
     public static void reached(String function, int branchID) {
         if (!branchesReached.containsKey(function)) branchesReached.put(function, new HashSet<>());
         branchesReached.get(function).add(branchID);
-        writeCoverage(function);
-    }
-
-    /**
-     * Prints the branch coverage for a specific function. Undefined behaviour if totalBranches
-     * is not positive.
-     * @param function The name of the function which was previously used when denoting the branches as having been reached.
-     */
-    public static void printCoverage(String function) {
-        System.out.println(getPrintCoverage(function));
+        writeCoverage();
     }
 
     /**
      * Write the current branch coverage to disk.
      * @param function The function identifier.
      */
-    public static void writeCoverage(String function) {
-        File f = new File("./build/coverage/" + function + ".txt");
+    public static void writeCoverage() {
+        File f = new File("./build/coverage/coverage.txt");
         f.getParentFile().mkdirs();
         try {
             FileWriter fw = new FileWriter(f);
             BufferedWriter bw = new BufferedWriter(fw);
-            bw.write(getPrintCoverage(function));
+            bw.write(getPrintCoverage());
             bw.close();
             fw.close();
         } catch (IOException e) {
@@ -73,16 +64,26 @@ public class Coverage {
         return totalBranches;
     }
 
-    private static String getPrintCoverage(String function) {
-        String str = "============================\n";
-        int totalBranches = getTotalBranches(function);
-        int branches = branchesReached.get(function) != null ? branchesReached.get(function).size() : 0;
-        str += String.format("Coverage for %s: %.1f%%\n", function, ((double) branches * 100) / totalBranches);
-        str += "Taken branchIDs:";
-        for (Integer branch : branchesReached.get(function)) {
-            str += " " + branch;
+    private static String getPrintCoverage() {
+        String str = "";
+        for (String function : branchesReached.keySet()) {
+            str += "============================\n";
+            int totalBranches = getTotalBranches(function);
+            int branches = branchesReached.get(function) != null ? branchesReached.get(function).size() : 0;
+            str += String.format("Coverage for %s: %.1f%%\n", function, ((double) branches * 100) / totalBranches);
+            str += "Taken branchIDs:";
+            for (Integer branch : branchesReached.get(function)) {
+                str += " " + branch;
+            }
+            str += "\nNon-taken branchIDs:";
+            for (int i = 0; i < totalBranches; ++i) {
+                if (branchesReached.get(function) != null) {
+                    if (!branchesReached.get(function).contains(i))
+                        str += " " + i;
+                }
+            }
+            str += "\n============================\n\n";
         }
-        str += "\n============================\n";
         return str;
     }
 }

--- a/src/main/java/org/mockito/Coverage.java
+++ b/src/main/java/org/mockito/Coverage.java
@@ -41,7 +41,6 @@ public class Coverage {
 
     /**
      * Write the current branch coverage to disk.
-     * @param function The function identifier.
      */
     public static void writeCoverage() {
         File f = new File("./build/coverage/coverage.txt");
@@ -71,11 +70,11 @@ public class Coverage {
             int totalBranches = getTotalBranches(function);
             int branches = branchesReached.get(function) != null ? branchesReached.get(function).size() : 0;
             str += String.format("Coverage for %s: %.1f%%\n", function, ((double) branches * 100) / totalBranches);
-            str += "Taken branchIDs:";
+            str += "Taken branchIDs (" + branches + "):";
             for (Integer branch : branchesReached.get(function)) {
                 str += " " + branch;
             }
-            str += "\nNon-taken branchIDs:";
+            str += "\nNon-taken branchIDs (" + (totalBranches-branches) + "):";
             for (int i = 0; i < totalBranches; ++i) {
                 if (branchesReached.get(function) != null) {
                     if (!branchesReached.get(function).contains(i))

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -5,6 +5,8 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.agent.ByteBuddyAgent;
+
+import org.mockito.Coverage;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.InstantiationException;
 import org.mockito.creation.instance.Instantiator;
@@ -223,18 +225,24 @@ class InlineDelegateByteBuddyMockMaker
     private final ThreadLocal<Object> currentSpied = new ThreadLocal<>();
 
     InlineDelegateByteBuddyMockMaker() {
+        Coverage.setTotalBranches("InlineDelegateByteBuddyMockMaker", 9);
+        Coverage.reached("InlineDelegateByteBuddyMockMaker", 0);
         if (INITIALIZATION_ERROR != null) {
+            Coverage.reached("InlineDelegateByteBuddyMockMaker", 1);
             String detail;
             if (PlatformUtils.isAndroidPlatform() || PlatformUtils.isProbablyTermuxEnvironment()) {
+                Coverage.reached("InlineDelegateByteBuddyMockMaker", 2);
                 detail =
                         "It appears as if you are trying to run this mock maker on Android which does not support the instrumentation API.";
             } else {
+                Coverage.reached("InlineDelegateByteBuddyMockMaker", 3);
                 try {
                     if (INITIALIZATION_ERROR instanceof NoClassDefFoundError
                             && INITIALIZATION_ERROR.getMessage() != null
                             && INITIALIZATION_ERROR
                                     .getMessage()
                                     .startsWith("net/bytebuddy/agent/")) {
+                        Coverage.reached("InlineDelegateByteBuddyMockMaker", 4);
                         detail =
                                 join(
                                         "It seems like you are running Mockito with an incomplete or inconsistent class path. Byte Buddy Agent could not be loaded.",
@@ -245,13 +253,16 @@ class InlineDelegateByteBuddyMockMaker
                                     .getMethod("getSystemJavaCompiler")
                                     .invoke(null)
                             == null) {
+                        Coverage.reached("InlineDelegateByteBuddyMockMaker", 5);
                         detail =
                                 "It appears as if you are running on a JRE. Either install a JDK or add JNA to the class path.";
                     } else {
+                        Coverage.reached("InlineDelegateByteBuddyMockMaker", 6);
                         detail =
                                 "It appears as if your JDK does not supply a working agent attachment mechanism.";
                     }
                 } catch (Throwable ignored) {
+                    Coverage.reached("InlineDelegateByteBuddyMockMaker", 7);
                     detail =
                             "It appears as if you are running an incomplete JVM installation that might not support all tooling APIs";
                 }
@@ -263,6 +274,8 @@ class InlineDelegateByteBuddyMockMaker
                             detail,
                             Platform.describe()),
                     INITIALIZATION_ERROR);
+        } else {
+            Coverage.reached("InlineDelegateByteBuddyMockMaker", 8);
         }
 
         ThreadLocal<Class<?>> currentConstruction = new ThreadLocal<>();

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -48,6 +48,7 @@ import net.bytebuddy.jar.asm.Type;
 import net.bytebuddy.pool.TypePool;
 import net.bytebuddy.utility.OpenedClassReader;
 
+import org.mockito.Coverage;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher;
@@ -392,7 +393,10 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                 TypePool typePool,
                 int writerFlags,
                 int readerFlags) {
+            Coverage.setTotalBranches("wrap", 8);
+            Coverage.reached("wrap", 0);
             if (instrumentedMethod.isConstructor() && !instrumentedType.represents(Object.class)) {
+                Coverage.reached("wrap", 1);
                 MethodList<MethodDescription.InDefinedShape> constructors =
                         instrumentedType
                                 .getSuperClass()
@@ -403,17 +407,22 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                 boolean packagePrivate = true;
                 MethodDescription.InDefinedShape current = null;
                 for (MethodDescription.InDefinedShape constructor : constructors) {
+                    Coverage.reached("wrap", 2);
                     // We are choosing the shortest constructor with regards to arguments.
                     // Yet, we prefer a non-package-private constructor since they require
                     // the super class to be on the same class loader.
                     if (constructor.getParameters().size() < arguments
                             && (packagePrivate || !constructor.isPackagePrivate())) {
+                                Coverage.reached("wrap", 3);
                         arguments = constructor.getParameters().size();
                         packagePrivate = constructor.isPackagePrivate();
                         current = constructor;
+                    } else {
+                        Coverage.reached("wrap", 4);
                     }
                 }
                 if (current != null) {
+                    Coverage.reached("wrap", 5);
                     final MethodDescription.InDefinedShape selected = current;
                     return new MethodVisitor(OpenedClassReader.ASM_API, methodVisitor) {
                         @Override
@@ -637,7 +646,11 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                             super.visitMaxs(Math.max(maxStack, prequel), maxLocals);
                         }
                     };
+                } else {
+                    Coverage.reached("wrap", 6);
                 }
+            } else {
+                Coverage.reached("wrap", 7);
             }
             return methodVisitor;
         }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ModuleHandler.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ModuleHandler.java
@@ -13,6 +13,8 @@ import net.bytebuddy.implementation.MethodCall;
 import net.bytebuddy.implementation.StubMethod;
 import net.bytebuddy.utility.GraalImageCode;
 import net.bytebuddy.utility.RandomString;
+
+import org.mockito.Coverage;
 import org.mockito.Mockito;
 import org.mockito.codegen.InjectionBase;
 import org.mockito.exceptions.base.MockitoException;
@@ -168,13 +170,19 @@ abstract class ModuleHandler {
 
         @Override
         void adjustModuleGraph(Class<?> source, Class<?> target, boolean export, boolean read) {
+            Coverage.setTotalBranches("adjustModuleGraph", 14);
+            Coverage.reached("adjustModuleGraph", 0);
             boolean needsExport = export && !isExported(source, target);
             boolean needsRead = read && !canRead(source, target);
             if (!needsExport && !needsRead) {
+                Coverage.reached("adjustModuleGraph", 1);
                 return;
+            } else {
+                Coverage.reached("adjustModuleGraph", 2);
             }
             ClassLoader classLoader = source.getClassLoader();
             if (classLoader == null) {
+                Coverage.reached("adjustModuleGraph", 3);
                 throw new MockitoException(
                         join(
                                 "Cannot adjust module graph for modules in the bootstrap loader",
@@ -183,20 +191,25 @@ abstract class ModuleHandler {
                                         + " is declared by the bootstrap loader and cannot be adjusted",
                                 "Requires package export to " + target + ": " + needsExport,
                                 "Requires adjusted reading of " + target + ": " + needsRead));
+            } else {
+                Coverage.reached("adjustModuleGraph", 4);
             }
             boolean targetVisible = classLoader == target.getClassLoader();
             while (!targetVisible && classLoader != null) {
+                Coverage.reached("adjustModuleGraph", 5);
                 classLoader = classLoader.getParent();
                 targetVisible = classLoader == target.getClassLoader();
             }
             MethodCall targetLookup;
             Implementation.Composable implementation;
             if (targetVisible) {
+                Coverage.reached("adjustModuleGraph", 6);
                 targetLookup =
                         MethodCall.invoke(getModule)
                                 .onMethodCall(MethodCall.invoke(forName).with(target.getName()));
                 implementation = StubMethod.INSTANCE;
             } else {
+                Coverage.reached("adjustModuleGraph", 7);
                 Class<?> intermediate;
                 Field field;
                 try {
@@ -227,6 +240,7 @@ abstract class ModuleHandler {
                     field = intermediate.getField("mockitoType");
                     field.set(null, target);
                 } catch (Exception e) {
+                    Coverage.reached("adjustModuleGraph", 8);
                     throw new MockitoException(
                             join(
                                     "Could not create a carrier for making the Mockito type visible to "
@@ -245,19 +259,25 @@ abstract class ModuleHandler {
                     MethodCall.invoke(getModule)
                             .onMethodCall(MethodCall.invoke(forName).with(source.getName()));
             if (needsExport) {
+                Coverage.reached("adjustModuleGraph", 9);
                 implementation =
                         implementation.andThen(
                                 MethodCall.invoke(addExports)
                                         .onMethodCall(sourceLookup)
                                         .with(target.getPackage().getName())
                                         .withMethodCall(targetLookup));
+            } else {
+                Coverage.reached("adjustModuleGraph", 10);
             }
             if (needsRead) {
+                Coverage.reached("adjustModuleGraph", 11);
                 implementation =
                         implementation.andThen(
                                 MethodCall.invoke(addReads)
                                         .onMethodCall(sourceLookup)
                                         .withMethodCall(targetLookup));
+            } else {
+                Coverage.reached("adjustModuleGraph", 12);
             }
             try {
                 Class.forName(
@@ -282,6 +302,7 @@ abstract class ModuleHandler {
                         true,
                         source.getClassLoader());
             } catch (Exception e) {
+                Coverage.reached("adjustModuleGraph", 13);
                 throw new MockitoException(
                         join(
                                 "Could not force module adjustment of the module of " + source,

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -126,7 +126,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
 
     @Override
     public <T> Class<? extends T> mockClass(MockFeatures<T> features) {
-        Coverage.setTotalBranches("mockClass", 8);
+        Coverage.setTotalBranches("mockClass", 37);
         Coverage.reached("mockClass", 0);
         MultipleParentClassLoader.Builder loaderBuilder =
                 new MultipleParentClassLoader.Builder()

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -41,6 +41,8 @@ import net.bytebuddy.implementation.attribute.MethodAttributeAppender;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.GraalImageCode;
 import net.bytebuddy.utility.RandomString;
+
+import org.mockito.Coverage;
 import org.mockito.codegen.InjectionBase;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.bytebuddy.ByteBuddyCrossClassLoaderSerializationSupport.CrossClassLoaderSerializableMock;
@@ -124,6 +126,8 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
 
     @Override
     public <T> Class<? extends T> mockClass(MockFeatures<T> features) {
+        Coverage.setTotalBranches("mockClass", 8);
+        Coverage.reached("mockClass", 0);
         MultipleParentClassLoader.Builder loaderBuilder =
                 new MultipleParentClassLoader.Builder()
                         .appendMostSpecific(features.mockedType)
@@ -137,6 +141,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
         ClassLoader contextLoader = currentThread().getContextClassLoader();
         boolean shouldIncludeContextLoader = true;
         if (needsSamePackageClassLoader(features)) {
+            Coverage.reached("mockClass", 1);
             // For the generated class to access package-private methods, it must be defined by the
             // same classloader as its type. All the other added classloaders are required to load
             // the type; if the context classloader is a child of the mocked type's defining
@@ -144,14 +149,23 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
             // loader is a child of the classloader we'd otherwise use, and possibly skip it.
             ClassLoader candidateLoader = loaderBuilder.build();
             for (ClassLoader parent = contextLoader; parent != null; parent = parent.getParent()) {
+                Coverage.reached("mockClass", 2);
                 if (parent == candidateLoader) {
+                    Coverage.reached("mockClass", 3);
                     shouldIncludeContextLoader = false;
                     break;
+                } else {
+                    Coverage.reached("mockClass", 4);
                 }
             }
+        } else {
+            Coverage.reached("mockClass", 5);
         }
         if (shouldIncludeContextLoader) {
+            Coverage.reached("mockClass", 6);
             loaderBuilder = loaderBuilder.appendMostSpecific(contextLoader);
+        } else {
+            Coverage.reached("mockClass", 7);
         }
         ClassLoader classLoader = loaderBuilder.build();
 
@@ -173,8 +187,10 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
         if (localMock
                 || (loader instanceof MultipleParentClassLoader
                         && !isComingFromJDK(features.mockedType))) {
+            Coverage.reached("mockClass", 8);
             typeName = features.mockedType.getName();
         } else {
+            Coverage.reached("mockClass", 9);
             typeName =
                     InjectionBase.class.getPackage().getName()
                             + "."
@@ -188,17 +204,26 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
                         GraalImageCode.getCurrent().isDefined()
                                 ? suffix(features)
                                 : RandomString.make());
+        if (GraalImageCode.getCurrent().isDefined()) {
+            Coverage.reached("mockClass", 10);
+        } else {
+            Coverage.reached("mockClass", 11);
+        }
 
         if (localMock) {
+            Coverage.reached("mockClass", 12);
             handler.adjustModuleGraph(features.mockedType, MockAccess.class, false, true);
             for (Class<?> iFace : features.interfaces) {
+                Coverage.reached("mockClass", 13);
                 handler.adjustModuleGraph(iFace, features.mockedType, true, false);
                 handler.adjustModuleGraph(features.mockedType, iFace, false, true);
             }
         } else {
+            Coverage.reached("mockClass", 14);
             boolean exported = handler.isExported(features.mockedType);
             Iterator<Class<?>> it = features.interfaces.iterator();
             while (exported && it.hasNext()) {
+                Coverage.reached("mockClass", 15);
                 exported = handler.isExported(it.next());
             }
             // We check if all mocked types are exported without qualification to avoid generating a
@@ -207,15 +232,19 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
             // makes this a
             // worthy performance optimization.
             if (exported) {
+                Coverage.reached("mockClass", 16);
                 assertVisibility(features.mockedType);
                 for (Class<?> iFace : features.interfaces) {
+                    Coverage.reached("mockClass", 17);
                     assertVisibility(iFace);
                 }
             } else {
+                Coverage.reached("mockClass", 18);
                 Class<?> hook = handler.injectionBase(classLoader, typeName);
                 assertVisibility(features.mockedType);
                 handler.adjustModuleGraph(features.mockedType, hook, true, false);
                 for (Class<?> iFace : features.interfaces) {
+                    Coverage.reached("mockClass", 19);
                     assertVisibility(iFace);
                     handler.adjustModuleGraph(iFace, hook, true, false);
                 }
@@ -229,6 +258,11 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
                 GraalImageCode.getCurrent().isDefined() && features.mockedType.isInterface()
                         ? (Class<T>) Object.class
                         : features.mockedType;
+        if (GraalImageCode.getCurrent().isDefined() && features.mockedType.isInterface()) {
+            Coverage.reached("mockClass", 20);
+        } else {
+            Coverage.reached("mockClass", 21);
+        }
         // If we create a mock for an interface with additional interfaces implemented, we do not
         // want to preserve the annotations of either interface. The caching mechanism does not
         // consider the order of these interfaces and the same mock class might be reused for
@@ -236,10 +270,13 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
         // preserved for interfaces in Java.
         Annotation[] annotationsOnType;
         if (features.stripAnnotations) {
+            Coverage.reached("mockClass", 22);
             annotationsOnType = new Annotation[0];
         } else if (!features.mockedType.isInterface() || features.interfaces.isEmpty()) {
+            Coverage.reached("mockClass", 23);
             annotationsOnType = features.mockedType.getAnnotations();
         } else {
+            Coverage.reached("mockClass", 24);
             annotationsOnType = new Annotation[0];
         }
         DynamicType.Builder<T> builder =
@@ -274,24 +311,48 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
                         .intercept(hashCode)
                         .method(isEquals())
                         .intercept(equals);
+        if (GraalImageCode.getCurrent().isDefined()) {
+            Coverage.reached("mockClass", 25);
+            if (GraalImageCode.getCurrent().isDefined() && features.mockedType.isInterface()) {
+                Coverage.reached("mockClass", 26);
+            } else {
+                Coverage.reached("mockClass", 27);
+            }
+        } else {
+            Coverage.reached("mockClass", 28);
+        }
+        if (features.stripAnnotations) {
+            Coverage.reached("mockClass", 29);
+        } else {
+            Coverage.reached("mockClass", 30);
+        }
         if (features.serializableMode == SerializableMode.ACROSS_CLASSLOADERS) {
+            Coverage.reached("mockClass", 31);
             builder =
                     builder.implement(CrossClassLoaderSerializableMock.class)
                             .intercept(writeReplace);
+        } else {
+            Coverage.reached("mockClass", 32);
         }
         if (readReplace != null) {
+            Coverage.reached("mockClass", 33);
             builder =
                     builder.defineMethod("readObject", void.class, Visibility.PRIVATE)
                             .withParameters(ObjectInputStream.class)
                             .throwing(ClassNotFoundException.class, IOException.class)
                             .intercept(readReplace);
+        } else {
+            Coverage.reached("mockClass", 34);
         }
         if (name.startsWith(CODEGEN_PACKAGE) || classLoader instanceof MultipleParentClassLoader) {
+            Coverage.reached("mockClass", 35);
             builder =
                     builder.ignoreAlso(
                             isPackagePrivate()
                                     .or(returns(isPackagePrivate()))
                                     .or(hasParameters(whereAny(hasType(isPackagePrivate())))));
+        } else {
+            Coverage.reached("mockClass", 36);
         }
         return builder.make()
                 .load(


### PR DESCRIPTION
Implementation of the DIY coverage tool in the form of `Coverage.java`.
Interface: 
* `setTotalBranches(String function, int totalBranches)` - Initialize the number of branches in the function (can be done repeatedly, but has to be done before writing the coverage log)
* `reached(String function, int branchID)` - At each branch, mark the branch as having been reached by the function identifier and the unique branch identifier.

To gather the coverage information, place out appropriate instances of `reached` at each branch in the function, then do `./gradlew build`. The class writes the coverage log to `build/coverage/` after each call to `reached`, so that it will have the latest coverage information upon terminating.

The "non-taken" branches assume ascending ordering of branchIDs, such that each ID is in the range [0, totalBranches).

The following coverage information should be obtained with the existing test suite:

```
============================
Coverage for mockClass: 78,4%
Taken branchIDs (29): 0 1 2 3 4 5 6 7 8 9 11 12 13 14 15 16 17 21 22 23 24 28 29 30 32 33 34 35 36
Non-taken branchIDs (8): 10 18 19 20 25 26 27 31
============================

============================
Coverage for adjustModuleGraph: 14,3%
Taken branchIDs (2): 0 1
Non-taken branchIDs (12): 2 3 4 5 6 7 8 9 10 11 12 13
============================

============================
Coverage for InlineDelegateByteBuddyMockMaker: 22,2%
Taken branchIDs (2): 0 8
Non-taken branchIDs (7): 1 2 3 4 5 6 7
============================

============================
Coverage for wrap: 87,5%
Taken branchIDs (7): 0 1 2 3 4 5 7
Non-taken branchIDs (1): 6
============================
```

Closes #3