### PR TITLE
Refactoring plan

### DIFF
--- a/report.md
+++ b/report.md
@@ -17,7 +17,7 @@ The could be built and run as documented in the project README. To build the pro
 The complexity measurement tool lizard was run on the code base to identify four large functions. The cyclomatic complexity of these functions was also counted by hand. We ran lizard using the command `lizard src/ -x"./src/tests/*" -l java -T nloc=100` and obtained the following results:
 
 | NLOC | CCN | location                                                                   | file                                                                                         |
-|------|-----|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| ---- | --- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | 119  | 24  | InlineDelegateByteBuddyMockMaker::InlineDelegateByteBuddyMockMaker@225-348 | @src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java |
 | 234  | 27  | MockMethodAdvice::ConstructorShortcut::wrap@387-643                        | @src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java                 |
 | 123  | 13  | ModuleHandler::ModuleSystemFound::adjustModuleGraph@170-292                | @src/main/java/org/mockito/internal/creation/bytebuddy/ModuleHandler.java                    |
@@ -29,7 +29,7 @@ The complexity measurement tool lizard was run on the code base to identify four
 From this, we picked out the first 4 functions to count manually: 
 
 | function                         | CCN | CCN manual1 | CCN manual2 |
-|----------------------------------|-----|-------------|-------------|
+| -------------------------------- | --- | ----------- | ----------- |
 | InlineDelegateByteBuddyMockMaker | 24  |             |             |
 | wrap                             | 27  |             |             |
 | adjustModuleGraph                | 13  |             |             |
@@ -39,9 +39,6 @@ From this, we picked out the first 4 functions to count manually:
 * wrap (in the ConstructorShortcut class in MockMethodAdvice), with NLOC = 234 and CC = 27. Manual count CC = 27. 
 * adjustModuleGraph (in ModuleSystemFound class in ModuleHandler) with NLOC = 123 and CC = 13. Manual count CC = 13 if not counting throws, otherwise 10. The function is used to adjust a module graph of a source module so that a mock can be created.
 * mockClass (in SubclassBytecodeGenerator) with NLOC = 149 and CC = 34. Manual count CC = 34. The purpose of the function is to create a mock class.
-
-
-
 1. What are your results for five complex functions?
    * Did all methods (tools vs. manual count) get the same result?
    * Are the results clear?
@@ -64,6 +61,104 @@ Plan for refactoring complex code:
 
 Estimated impact of refactoring (lower CC, but other drawbacks?).
 
+Method InlineDelegateByteBuddyMockMaker::InlineDelegateByteBuddyMockMaker():
+
+- CCN: 24
+
+- Possible refactor: a large part at the beginning (lines 263 to 265) can be extracted into a separate function. This code deals with initialization error and is independent from the object creation. This part greatly lowers the CC yet has no real drawback. With only this refactor, the function is still above 15 CCN according to lizard's computation method. If needed, we can also refactor the lambda method to assign `isMockConstruction`  (lines 293 to 337) into a separate method.
+
+Method ArrayEquals::matches(Object):
+
+- CCN: 21
+
+- Problem: this is basically a big switch structure, where we have to check all the time for the current array's type (always some basic one), same for the target array and then check equality
+
+- Posssible refactor: as the code always checks the instance of the target array against the actual array given as parameter, we can remove testing the instance of the `actual` array, if we check whether or not the target and actual array are of the same instance at the beginning by `if(wanted.getClass().isInstance(actual)) {return false;}`. Should not create other problems.
+
+Method EqualsBuilder::append(Object[], Object[]):
+
+- CCN: 17
+
+- Problem: it's not too easy to refactor this one. One way is to try to make sense of the type dispatching. But this may caus tests on this method to fail (it did in my attempt at refactoring it). Another is to pick the first lines returning `this` if the arrays are null, known to be different already, or their pointers are the same for a new method
+  
+  ```java
+  // Returns true if the objects are known to be non-equal, if any is null, or if they are
+  // the same pointer
+  
+  private boolean checkNoWorkToBeDone(Object lhs, Object rhs) {
+      if (!isEquals) {
+          return true;
+      }
+      if (lhs == rhs) {
+          return true;
+      }
+      if (lhs == null || rhs == null) {
+          this.setEquals(false);
+          return true;
+      }
+      return false;
+  }
+  ```
+  
+  This stilll causes an error, but because one test checks how long it takes to do an operation and with the new method it takes longer. We will not implement this one.
+
+Method ModuleHandler::adjustModuleGraph(Class, Class, boolean, boolean):
+
+- CCN: 13
+
+- Possible refactoring: a few parts can be extracted into separate functions, e.g.
+  
+  - ```java
+    while (!targetVisible && classLoader != null) {
+                    classLoader = classLoader.getParent();
+                    targetVisible = classLoader == target.getClassLoader();
+    }
+    ```
+
+```java
+if (needsExport) {
+                implementation =
+                        implementation.andThen(
+                                MethodCall.invoke(addExports)
+                                        .onMethodCall(sourceLookup)
+                                        .with(target.getPackage().getName())
+                                        .withMethodCall(targetLookup));
+            }
+            if (needsRead) {
+                implementation =
+                        implementation.andThen(
+                                MethodCall.invoke(addReads)
+                                        .onMethodCall(sourceLookup)
+                                        .withMethodCall(targetLookup));
+            }
+```
+
+    This should help to decrease the CCN while not changing the behaviour.
+
+Method SubclassBytecodeGenerator::mockClass(MockFeatures):
+
+- CCN: 34
+
+- Possible refactoring: extract the following code lines into dedicated methods (it should reduce the CCN, but increase the time for execution by a bit):
+  
+  - 139-152: this is a handler in case we don't have the same class loader yet, return a boolean and assign it to `shouldIncludeContextLoader`, change the break for a return.
+  
+  - 166-223: extract this into a `handleMockLocalOrNot(MockFeatures<T> features, ClassLoader classLoader)` method and give `features` as argument (should be of void return type)
+  
+  - 238-244: extract into an annotation handler, no return and takes Annotation[] as argument
+  
+  - 277-295: make a function to add properties/behaviour to the builder
+
+- Documentation: the documentation inside the class may be used to create the documentation for these new methods.
+
+Method MockMethodAdvice::ConstructorShortcut::wrap(...):
+
+- CCN: 27
+
+- Problem: a new class is defined in the return of the function, and holds most of the complexity.
+
+- Possible refactor: create a new class that inherits from MethodVisitor and overrides the given functions. This new class will take most of the complexity away. We can further extract lines 591 to 623 as they have a common condition to be executed. Instead of using twice the same conditions we can merge them, specifying via comments the delimitation between the two parts as they create variables of the same name. It would take `implementationContext`, `instrumentedType` and `instrumentedMethod` as parameters. We can also extract lines 409 to 414 as this part deals with the specific of a private constructor.
+
 Carried out refactoring (optional, P+):
 
 git diff ...
@@ -73,8 +168,6 @@ git diff ...
 ### Tools
 
 The tool used to measure code coverage was jacoco. It was already integrated in the existing build environment which made it easy to use with the command `./gradlew coverageReport`. This generated a html file with information about the coverage for all the functions in the project. 
-
-
 
 Document your experience in using a "new"/different coverage tool.
 
@@ -130,4 +223,4 @@ Where is potential for improvement?
 
 What are your main take-aways from this project? What did you learn?
 
-Is there something special you want to mention here?
+Is there something special you want to mention here

--- a/report.md
+++ b/report.md
@@ -75,7 +75,7 @@ Method ArrayEquals::matches(Object):
 
 - Posssible refactor: as the code always checks the instance of the target array against the actual array given as parameter, we can remove testing the instance of the `actual` array, if we check whether or not the target and actual array are of the same instance at the beginning by `if(wanted.getClass().isInstance(actual)) {return false;}`. Should not create other problems.
 
-Method EqualsBuilder::append(Object[], Object[]):
+Method EqualsBuilder::append(Object, Object):
 
 - CCN: 17
 

--- a/report.md
+++ b/report.md
@@ -65,7 +65,7 @@ Method InlineDelegateByteBuddyMockMaker::InlineDelegateByteBuddyMockMaker():
 
 - CCN: 24
 
-- Possible refactor: a large part at the beginning (lines 263 to 265) can be extracted into a separate function. This code deals with initialization error and is independent from the object creation. This part greatly lowers the CC yet has no real drawback. With only this refactor, the function is still above 15 CCN according to lizard's computation method. If needed, we can also refactor the lambda method to assign `isMockConstruction`  (lines 293 to 337) into a separate method.
+- Possible refactor: a large part at the beginning (lines 227 to 265) can be extracted into a separate function. This code deals with initialization error and is independent from the object creation. This part greatly lowers the CC yet has no real drawback. With only this refactor, the function is still above 15 CCN according to lizard's computation method. If needed, we can also refactor the lambda method to assign `onConstruction`  (lines 293 to 337) into a separate method. We can in the same way extract the lambda for `isMockConstruction` (lines (274-292) but it is not necessary as the above reduce most of the CCN.
 
 Method ArrayEquals::matches(Object):
 


### PR DESCRIPTION
Part of issue #6.
The plan describes the refactoring for 6 methods (4 required), so we have a bit of choice for simpler methods if we attempt P+. One is not meant to be refactored as written in the plan, as trying to implement the refactors leaded to the detailed errors.

