### PR TITLE
Issue/5 coverage improvement equalsbuilder

### DIFF
--- a/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
@@ -448,6 +448,20 @@ public class EqualsBuilderTest extends TestBase {
     }
 
     @Test
+    public void testEqualBigDecimal() {
+        BigDecimal o1 = new BigDecimal("42.0");
+        BigDecimal o2 = new BigDecimal("42.0");
+        assertTrue(new EqualsBuilder().append(o1, o2).isEquals());
+    }
+
+    @Test
+    public void testOneBigDecimal() {
+        BigDecimal o1 = new BigDecimal("42.0");
+        int o2 = 41;
+        assertFalse(new EqualsBuilder().append(o1, o2).isEquals());
+    }
+
+    @Test
     public void testAccessors() {
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         assertTrue(equalsBuilder.isEquals());

--- a/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
@@ -547,6 +547,20 @@ public class EqualsBuilderTest extends TestBase {
     }
 
     @Test
+    public void testIntArrayOfDifferentLength() {
+        int[] obj1 = {1, 2, 3};
+        int[] obj2 = {1, 2, 3, 4, 5, 6, 7};
+        assertFalse(new EqualsBuilder().append(obj1, obj2).isEquals());
+    }
+
+    @Test
+    public void testIntArrayEmptyArrays() {
+        int[] obj1 = new int[0];
+        int[] obj2 = new int[0];
+        assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
+    }
+
+    @Test
     public void testShortArray() {
         short[] obj1 = new short[2];
         obj1[0] = 5;


### PR DESCRIPTION
Adds 2 tests for EqualsBuilder::append(Object lhs, Object rhs):

    one with two equals BigDecimal
    one with one BigDecimal and one primitive type

Raises the coverage from 94% to 97% according to jacoco

Adds 2 tests for EqualsBuilder::append(int[] lhs, int[] rhs):

    one with two arrays of different size
    one with two empty arrays

Raises the coverage from 71% to 78% according to jacoco.

Part of issue https://github.com/haaker1/mockito/issues/5.